### PR TITLE
feat(db): Add atom templates (theme and syntax)

### DIFF
--- a/db/templates/atom-syntax/dark.nunjucks
+++ b/db/templates/atom-syntax/dark.nunjucks
@@ -1,0 +1,33 @@
+// Atom template by Jan T. Sott (https://github.com/idleberg/)
+// Base16 scheme and Base16 Builder by Chris Kempson (https://github.com/chriskempson)
+
+// This defines all syntax variables that syntax themes must implement when they
+// include a syntax-variables.less file.
+
+// General colors
+@syntax-text-color: #{{ base["05"]["hex"] }};
+@syntax-cursor-color: #{{ base["05"]["hex"] }};
+@syntax-selection-color: #{{ base["02"]["hex"] }};
+@syntax-background-color: #{{ base["00"]["hex"] }};
+
+// Guide colors
+@syntax-wrap-guide-color: #{{ base["03"]["hex"] }};
+@syntax-indent-guide-color: #{{ base["03"]["hex"] }};
+@syntax-invisible-character-color: #{{ base["03"]["hex"] }};
+
+// For find and replace markers
+@syntax-result-marker-color: #{{ base["03"]["hex"] }};
+@syntax-result-marker-color-selected: #{{ base["05"]["hex"] }};
+
+// Gutter colors
+@syntax-gutter-text-color: #{{ base["05"]["hex"] }};
+@syntax-gutter-text-color-selected: #{{ base["05"]["hex"] }};
+@syntax-gutter-background-color: #{{ base["00"]["hex"] }};
+@syntax-gutter-background-color-selected: rgba(80, 80, 80, 0.33);
+
+// For git diff info. i.e. in the gutter
+// These are static and were not extracted from your textmate theme
+@syntax-color-renamed: #{{ base["0D"]["hex"] }};
+@syntax-color-added: #{{ base["0B"]["hex"] }};
+@syntax-color-modified: #{{ base["0A"]["hex"] }};
+@syntax-color-removed: #{{ base["08"]["hex"] }};

--- a/db/templates/atom-syntax/light.nunjucks
+++ b/db/templates/atom-syntax/light.nunjucks
@@ -1,0 +1,30 @@
+// This defines all syntax variables that syntax themes must implement when they
+// include a syntax-variables.less file.
+
+// General colors
+@syntax-text-color: #{{ base["02"]["hex"] }};
+@syntax-cursor-color: #{{ base["02"]["hex"] }};
+@syntax-selection-color: #{{ base["06"]["hex"] }};
+@syntax-background-color: #{{ base["07"]["hex"] }};
+
+// Guide colors
+@syntax-wrap-guide-color: #{{ base["06"]["hex"] }};
+@syntax-indent-guide-color: #{{ base["06"]["hex"] }};
+@syntax-invisible-character-color: #{{ base["06"]["hex"] }};
+
+// For find and replace markers
+@syntax-result-marker-color: #{{ base["06"]["hex"] }};
+@syntax-result-marker-color-selected: #{{ base["02"]["hex"] }};
+
+// Gutter colors
+@syntax-gutter-text-color: #{{ base["02"]["hex"] }};
+@syntax-gutter-text-color-selected: #{{ base["02"]["hex"] }};
+@syntax-gutter-background-color: #{{ base["07"]["hex"] }};
+@syntax-gutter-background-color-selected: rgba(176, 176, 176, 0.33);
+
+// For git diff info. i.e. in the gutter
+// These are static and were not extracted from your textmate theme
+@syntax-color-renamed: #{{ base["0D"]["hex"] }};
+@syntax-color-added: #{{ base["0B"]["hex"] }};
+@syntax-color-modified: #{{ base["0A"]["hex"] }};
+@syntax-color-removed: #{{ base["08"]["hex"] }};

--- a/db/templates/atom/dark.nunjucks
+++ b/db/templates/atom/dark.nunjucks
@@ -1,0 +1,224 @@
+// Atom template by Jan T. Sott (https://github.com/idleberg/)
+// Base16 scheme and Base16 Builder by Chris Kempson (https://github.com/chriskempson)
+
+@import "base16-{{ slug }}-dark-syntax-variables.less";
+atom-text-editor, // <- remove when Shadow DOM can't be disabled
+:host {
+  color: @syntax-text-color;
+  background-color: @syntax-background-color;
+  .gutter {
+    color: @syntax-gutter-text-color;
+    background-color: @syntax-gutter-background-color;
+  }
+
+  .gutter .line-number.cursor-line {
+    color: @syntax-gutter-text-color-selected;
+    background-color: @syntax-gutter-background-color-selected;
+  }
+
+  .gutter .line-number.cursor-line-no-selection {
+    color: @syntax-gutter-text-color-selected;
+  }
+
+  .wrap-guide {
+    color: @syntax-wrap-guide-color;
+  }
+
+  .indent-guide {
+    color: @syntax-indent-guide-color;
+  }
+
+  .invisible-character {
+    color: @syntax-invisible-character-color;
+  }
+
+  .search-results .marker .region {
+    background-color: transparent;
+    border: @syntax-result-marker-color;
+  }
+
+  .search-results .marker.current-result .region {
+    border: @syntax-result-marker-color-selected;
+  }
+
+  .cursor {
+    border-color: @syntax-cursor-color;
+  }
+
+  .selection .region {
+    background-color: @syntax-selection-color;
+  }
+
+  .line-number.cursor-line-no-selection, .line.cursor-line {
+    background-color: rgba(80, 80, 80, 0.33);
+  }
+
+}
+
+.variable.parameter.function {
+  color: #{{ base["05"]["hex"] }};
+}
+
+.comment, .punctuation.definition.comment {
+  color: #{{ base["03"]["hex"] }};
+}
+
+.punctuation.definition.string, .punctuation.definition.variable, .punctuation.definition.string, .punctuation.definition.parameters, .punctuation.definition.string, .punctuation.definition.array {
+  color: #{{ base["05"]["hex"] }};
+}
+
+.none {
+  color: #{{ base["05"]["hex"] }};
+}
+
+.keyword.operator {
+  color: #{{ base["05"]["hex"] }};
+}
+
+.keyword {
+  color: #{{ base["0E"]["hex"] }};
+}
+
+.variable {
+  color: #{{ base["08"]["hex"] }};
+}
+
+.entity.name.function, .meta.require, .support.function.any-method {
+  color: #{{ base["0D"]["hex"] }};
+}
+
+.support.class, .entity.name.class, .entity.name.type.class {
+  color: #{{ base["0A"]["hex"] }};
+}
+
+.meta.class {
+  color: #{{ base["07"]["hex"] }};
+}
+
+.keyword.other.special-method {
+  color: #{{ base["0D"]["hex"] }};
+}
+
+.storage {
+  color: #{{ base["0E"]["hex"] }};
+}
+
+.support.function {
+  color: #{{ base["0C"]["hex"] }};
+}
+
+.string, .constant.other.symbol, .entity.other.inherited-class {
+  color: #{{ base["0B"]["hex"] }};
+}
+
+.constant.numeric {
+  color: #{{ base["09"]["hex"] }};
+}
+
+.none {
+  color: #{{ base["09"]["hex"] }};
+}
+
+.none {
+  color: #{{ base["09"]["hex"] }};
+}
+
+.constant {
+  color: #{{ base["09"]["hex"] }};
+}
+
+.entity.name.tag {
+  color: #{{ base["08"]["hex"] }};
+}
+
+.entity.other.attribute-name {
+  color: #{{ base["09"]["hex"] }};
+}
+
+.entity.other.attribute-name.id, .punctuation.definition.entity {
+  color: #{{ base["0D"]["hex"] }};
+}
+
+.meta.selector {
+  color: #{{ base["0E"]["hex"] }};
+}
+
+.none {
+  color: #{{ base["09"]["hex"] }};
+}
+
+.markup.heading, .punctuation.definition.heading, .entity.name.section {
+  color: #{{ base["0D"]["hex"] }};
+}
+
+.keyword.other.unit {
+  color: #{{ base["09"]["hex"] }};
+}
+
+.markup.bold, .punctuation.definition.bold {
+  font-weight: bold;
+  color: #{{ base["0A"]["hex"] }};
+}
+
+.markup.italic, .punctuation.definition.italic {
+  font-style: italic;
+  color: #{{ base["0E"]["hex"] }};
+}
+
+.markup.raw.inline {
+  color: #{{ base["0B"]["hex"] }};
+}
+
+.string.other.link {
+  color: #{{ base["08"]["hex"] }};
+}
+
+.meta.link {
+  color: #{{ base["09"]["hex"] }};
+}
+
+.markup.list {
+  color: #{{ base["08"]["hex"] }};
+}
+
+.markup.quote {
+  color: #{{ base["09"]["hex"] }};
+}
+
+.meta.separator {
+  color: #{{ base["05"]["hex"] }};
+  background-color: #{{ base["02"]["hex"] }};
+}
+
+.markup.inserted {
+  color: #{{ base["0B"]["hex"] }};
+}
+
+.markup.deleted {
+  color: #{{ base["08"]["hex"] }};
+}
+
+.markup.changed {
+  color: #{{ base["0E"]["hex"] }};
+}
+
+.constant.other.color {
+  color: #{{ base["0C"]["hex"] }};
+}
+
+.string.regexp {
+  color: #{{ base["0C"]["hex"] }};
+}
+
+.constant.character.escape {
+  color: #{{ base["0C"]["hex"] }};
+}
+
+.punctuation.section.embedded, .variable.interpolation {
+  color: #{{ base["0F"]["hex"] }};
+}
+
+.invalid.illegal {
+  color: #{{ base["00"]["hex"] }};
+  background-color: #{{ base["08"]["hex"] }};
+}

--- a/db/templates/atom/light.nunjucks
+++ b/db/templates/atom/light.nunjucks
@@ -1,0 +1,225 @@
+// Atom template by Jan T. Sott (https://github.com/idleberg/)
+// Base16 scheme and Base16 Builder by Chris Kempson (https://github.com/chriskempson)
+
+@import "base16-{{ slug }}-light-syntax-variables.less";
+
+atom-text-editor, // <- remove when Shadow DOM can't be disabled
+:host {
+  color: @syntax-text-color;
+  background-color: @syntax-background-color;
+  .gutter {
+    color: @syntax-gutter-text-color;
+    background-color: @syntax-gutter-background-color;
+  }
+
+  .gutter .line-number.cursor-line {
+    color: @syntax-gutter-text-color-selected;
+    background-color: @syntax-gutter-background-color-selected;
+  }
+
+  .gutter .line-number.cursor-line-no-selection {
+    color: @syntax-gutter-text-color-selected;
+  }
+
+  .wrap-guide {
+    color: @syntax-wrap-guide-color;
+  }
+
+  .indent-guide {
+    color: @syntax-indent-guide-color;
+  }
+
+  .invisible-character {
+    color: @syntax-invisible-character-color;
+  }
+
+  .search-results .marker .region {
+    background-color: transparent;
+    border: @syntax-result-marker-color;
+  }
+
+  .search-results .marker.current-result .region {
+    border: @syntax-result-marker-color-selected;
+  }
+
+  .cursor {
+    border-color: @syntax-cursor-color;
+  }
+
+  .selection .region {
+    background-color: @syntax-selection-color;
+  }
+
+  .line-number.cursor-line-no-selection, .line.cursor-line {
+    background-color: rgba(176, 176, 176, 0.33);
+  }
+
+}
+
+.variable.parameter.function {
+  color: #{{ base["02"]["hex"] }};
+}
+
+.comment, .punctuation.definition.comment {
+  color: #{{ base["04"]["hex"] }};
+}
+
+.punctuation.definition.string, .punctuation.definition.variable, .punctuation.definition.string, .punctuation.definition.parameters, .punctuation.definition.string, .punctuation.definition.array {
+  color: #{{ base["02"]["hex"] }};
+}
+
+.none {
+  color: #{{ base["02"]["hex"] }};
+}
+
+.keyword.operator {
+  color: #{{ base["02"]["hex"] }};
+}
+
+.keyword {
+  color: #{{ base["0E"]["hex"] }};
+}
+
+.variable {
+  color: #{{ base["08"]["hex"] }};
+}
+
+.entity.name.function, .meta.require, .support.function.any-method {
+  color: #{{ base["0D"]["hex"] }};
+}
+
+.support.class, .entity.name.class, .entity.name.type.class {
+  color: #{{ base["09"]["hex"] }};
+}
+
+.meta.class {
+  color: #{{ base["01"]["hex"] }};
+}
+
+.keyword.other.special-method {
+  color: #{{ base["0D"]["hex"] }};
+}
+
+.storage {
+  color: #{{ base["0E"]["hex"] }};
+}
+
+.support.function {
+  color: #{{ base["0C"]["hex"] }};
+}
+
+.string, .constant.other.symbol, .entity.other.inherited-class {
+  color: #{{ base["0B"]["hex"] }};
+}
+
+.constant.numeric {
+  color: #{{ base["09"]["hex"] }};
+}
+
+.none {
+  color: #{{ base["09"]["hex"] }};
+}
+
+.none {
+  color: #{{ base["09"]["hex"] }};
+}
+
+.constant {
+  color: #{{ base["09"]["hex"] }};
+}
+
+.entity.name.tag {
+  color: #{{ base["08"]["hex"] }};
+}
+
+.entity.other.attribute-name {
+  color: #{{ base["09"]["hex"] }};
+}
+
+.entity.other.attribute-name.id, .punctuation.definition.entity {
+  color: #{{ base["0D"]["hex"] }};
+}
+
+.meta.selector {
+  color: #{{ base["0E"]["hex"] }};
+}
+
+.none {
+  color: #{{ base["09"]["hex"] }};
+}
+
+.markup.heading, .punctuation.definition.heading, .entity.name.section {
+  color: #{{ base["0D"]["hex"] }};
+}
+
+.keyword.other.unit {
+  color: #{{ base["09"]["hex"] }};
+}
+
+.markup.bold, .punctuation.definition.bold {
+  font-weight: bold;
+  color: #{{ base["09"]["hex"] }};
+}
+
+.markup.italic, .punctuation.definition.italic {
+  font-style: italic;
+  color: #{{ base["0E"]["hex"] }};
+}
+
+.markup.raw.inline {
+  color: #{{ base["0B"]["hex"] }};
+}
+
+.string.other.link {
+  color: #{{ base["08"]["hex"] }};
+}
+
+.meta.link {
+  color: #{{ base["09"]["hex"] }};
+}
+
+.markup.list {
+  color: #{{ base["08"]["hex"] }};
+}
+
+.markup.quote {
+  color: #{{ base["09"]["hex"] }};
+}
+
+.meta.separator {
+  color: #{{ base["02"]["hex"] }};
+  background-color: #{{ base["06"]["hex"] }};
+}
+
+.markup.inserted {
+  color: #{{ base["0B"]["hex"] }};
+}
+
+.markup.deleted {
+  color: #{{ base["08"]["hex"] }};
+}
+
+.markup.changed {
+  color: #{{ base["0E"]["hex"] }};
+}
+
+.constant.other.color {
+  color: #{{ base["0C"]["hex"] }};
+}
+
+.string.regexp {
+  color: #{{ base["0C"]["hex"] }};
+}
+
+.constant.character.escape {
+  color: #{{ base["0C"]["hex"] }};
+}
+
+.punctuation.section.embedded, .variable.interpolation {
+  color: #{{ base["0F"]["hex"] }};
+}
+
+.invalid.illegal {
+  color: #{{ base["07"]["hex"] }};
+  background-color: #{{ base["08"]["hex"] }};
+}


### PR DESCRIPTION
I splited the old folder in two folders. One is for the UI theme and the second for the syntax.

- [x] atom-syntax/dark.nunjucks
- [x] atom-syntax/light.nunjucks
- [x] atom/dark.nunjucks
- [x] atom/light.nunjucks

related to #23