### PR TITLE
feat(cli): Show help message when no arguments are supplied

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -38,6 +38,11 @@ require('babel-polyfill');
     }
   });
 
+  if (Object.keys(cli.flags).length === 0) {
+    cli.showHelp();
+    return;
+  }
+
   const {template: templNameOrPath, scheme: schemeNameOrPath, brightness} = cli.flags;
 
   if (!templNameOrPath || !schemeNameOrPath) {

--- a/tests/functionalTests.js
+++ b/tests/functionalTests.js
@@ -5,6 +5,14 @@ import execute from 'execa';
 
 const command = '../dist/cli.js';
 
+test('No arguments should cause help to be output', async function (t) {
+  const {stdout: actual} = await execute(command);
+
+  t.ok(actual.match(/Usage/));
+  t.ok(actual.match(/Options/));
+  t.ok(actual.match(/Example/));
+});
+
 test('help arguments should cause help to be output', async function (t) {
   const {stdout: actual} = await execute(command, ['--help']);
 
@@ -73,7 +81,6 @@ test('Given non-existent scheme name & non-existent template name, correct error
 
 test('Given invalid command arguments, correct error is emitted', async function (t) {
   const invalidCommandArguments = [
-    [],
     ['--template', 'i3wm'],
     ['--scheme', 'gooey'],
     ['--brightness', 'dark']


### PR DESCRIPTION
This behaviour is similar to that of npm and git's -- two popular tools with which base16-builders
are likely familiar

Closes #54