### PR TITLE
fix(db): Remove leading erb comment

### DIFF
--- a/db/templates/smartftp/dark.nunjucks
+++ b/db/templates/smartftp/dark.nunjucks
@@ -17,12 +17,12 @@ Windows Registry Editor Version 5.00
 "Color 5"=dword:00{{ base["06"]["hex"].match(/.{2}/g).reverse().join('') }}
 
 ; Black
-"Color 6"=dword:00{{ @base["00"]["hex"].match(/.{2}/g).reverse().join('') }}
-"Color 7"=dword:00{{ @base["03"]["hex"].match(/.{2}/g).reverse().join('') }}
+"Color 6"=dword:00{{ base["00"]["hex"].match(/.{2}/g).reverse().join('') }}
+"Color 7"=dword:00{{ base["03"]["hex"].match(/.{2}/g).reverse().join('') }}
 
 ; Red
-"Color 8"=dword:00{{ @base["08"]["hex"].match(/.{2}/g).reverse().join('') }}
-"Color 9"=dword:00{{ @base["08"]["hex"].match(/.{2}/g).reverse().join('') }}
+"Color 8"=dword:00{{ base["08"]["hex"].match(/.{2}/g).reverse().join('') }}
+"Color 9"=dword:00{{ base["08"]["hex"].match(/.{2}/g).reverse().join('') }}
 
 ; Green
 "Color 10"=dword:00{{ base["0B"]["hex"].match(/.{2}/g).reverse().join('') }}

--- a/db/templates/smartftp/dark.nunjucks
+++ b/db/templates/smartftp/dark.nunjucks
@@ -17,12 +17,12 @@ Windows Registry Editor Version 5.00
 "Color 5"=dword:00{{ base["06"]["hex"].match(/.{2}/g).reverse().join('') }}
 
 ; Black
-"Color 6"=dword:00<%=  @base["00"]["hex"].match(/.{2}/g).reverse().join('') }}
-"Color 7"=dword:00<%=  @base["03"]["hex"].match(/.{2}/g).reverse().join('') }}
+"Color 6"=dword:00{{ @base["00"]["hex"].match(/.{2}/g).reverse().join('') }}
+"Color 7"=dword:00{{ @base["03"]["hex"].match(/.{2}/g).reverse().join('') }}
 
 ; Red
-"Color 8"=dword:00<%=  @base["08"]["hex"].match(/.{2}/g).reverse().join('') }}
-"Color 9"=dword:00<%=  @base["08"]["hex"].match(/.{2}/g).reverse().join('') }}
+"Color 8"=dword:00{{ @base["08"]["hex"].match(/.{2}/g).reverse().join('') }}
+"Color 9"=dword:00{{ @base["08"]["hex"].match(/.{2}/g).reverse().join('') }}
 
 ; Green
 "Color 10"=dword:00{{ base["0B"]["hex"].match(/.{2}/g).reverse().join('') }}

--- a/db/templates/smartftp/light.nunjucks
+++ b/db/templates/smartftp/light.nunjucks
@@ -17,12 +17,12 @@ Windows Registry Editor Version 5.00
 "Color 5"=dword:00{{ base["01"]["hex"].match(/.{2}/g).reverse().join('') }}
 
 ; Black
-"Color 6"=dword:00<%=  @base["07"]["hex"].match(/.{2}/g).reverse().join('') }}
-"Color 7"=dword:00<%=  @base["04"]["hex"].match(/.{2}/g).reverse().join('') }}
+"Color 6"=dword:00{{ @base["07"]["hex"].match(/.{2}/g).reverse().join('') }}
+"Color 7"=dword:00{{ @base["04"]["hex"].match(/.{2}/g).reverse().join('') }}
 
 ; Red
-"Color 8"=dword:00<%=  @base["08"]["hex"].match(/.{2}/g).reverse().join('') }}
-"Color 9"=dword:00<%=  @base["08"]["hex"].match(/.{2}/g).reverse().join('') }}
+"Color 8"=dword:00{{ @base["08"]["hex"].match(/.{2}/g).reverse().join('') }}
+"Color 9"=dword:00{{ @base["08"]["hex"].match(/.{2}/g).reverse().join('') }}
 
 ; Green
 "Color 10"=dword:00{{ base["0B"]["hex"].match(/.{2}/g).reverse().join('') }}

--- a/db/templates/smartftp/light.nunjucks
+++ b/db/templates/smartftp/light.nunjucks
@@ -17,12 +17,12 @@ Windows Registry Editor Version 5.00
 "Color 5"=dword:00{{ base["01"]["hex"].match(/.{2}/g).reverse().join('') }}
 
 ; Black
-"Color 6"=dword:00{{ @base["07"]["hex"].match(/.{2}/g).reverse().join('') }}
-"Color 7"=dword:00{{ @base["04"]["hex"].match(/.{2}/g).reverse().join('') }}
+"Color 6"=dword:00{{ base["07"]["hex"].match(/.{2}/g).reverse().join('') }}
+"Color 7"=dword:00{{ base["04"]["hex"].match(/.{2}/g).reverse().join('') }}
 
 ; Red
-"Color 8"=dword:00{{ @base["08"]["hex"].match(/.{2}/g).reverse().join('') }}
-"Color 9"=dword:00{{ @base["08"]["hex"].match(/.{2}/g).reverse().join('') }}
+"Color 8"=dword:00{{ base["08"]["hex"].match(/.{2}/g).reverse().join('') }}
+"Color 9"=dword:00{{ base["08"]["hex"].match(/.{2}/g).reverse().join('') }}
 
 ; Green
 "Color 10"=dword:00{{ base["0B"]["hex"].match(/.{2}/g).reverse().join('') }}


### PR DESCRIPTION
I found some leading erb comment. The bug comes from a double whitespace between `<%=` and `@base`.