### PR TITLE
fix(cli): 'ls templates' should list complete package

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -65,9 +65,7 @@ import updateNotifier from 'update-notifier'
     try {
       const dirPath = path.join(__dirname, `db/templates`)
       const templatePaths = await fs.readdir(dirPath)
-      templatePaths
-        .map(filePath => filePath.split('.')[0])
-        .forEach(fileName => logger.log(fileName))
+      templatePaths.forEach(fileName => logger.log(fileName))
     } catch (err) {
       logger.error(err)
     }


### PR DESCRIPTION
ls templates would exclude everything after '.'  This would cause
an error when trying to generate an output file with the template
string that was displayed by 'ls templates'