### PR TITLE
fix(db): Use exclamation marks to comment in rofi

### DIFF
--- a/db/templates/rofi/dark.ejs
+++ b/db/templates/rofi/dark.ejs
@@ -1,10 +1,10 @@
-# vim: filetype=yaml
-# rofi template
-# Base16 <%- scheme %> Dark, by <%- author %>
+! vim: filetype=yaml
+! rofi template
+! Base16 <%- scheme %> Dark, by <%- author %>
 
-# State:           'bg',    'fg',    'bgalt', 'hlbg',  'hlfg'
+! State:           'bg',    'fg',    'bgalt', 'hlbg',  'hlfg'
 rofi.color-normal: #<%- base["00"]["hex"] %>, #<%- base["07"]["hex"] %>, #<%- base["00"]["hex"] %>, #<%- base["07"]["hex"] %>, #<%- base["00"]["hex"] %>
 rofi.color-urgent: #<%- base["00"]["hex"] %>, #<%- base["08"]["hex"] %>, #<%- base["00"]["hex"] %>, #<%- base["08"]["hex"] %>, #<%- base["00"]["hex"] %>
 rofi.color-active: #<%- base["00"]["hex"] %>, #<%- base["0D"]["hex"] %>, #<%- base["00"]["hex"] %>, #<%- base["0D"]["hex"] %>, #<%- base["00"]["hex"] %>
-#                  'bg',    'border'
+!                  'bg',    'border'
 rofi.color-window: #<%- base["00"]["hex"] %>, #<%- base["07"]["hex"] %>

--- a/db/templates/rofi/light.ejs
+++ b/db/templates/rofi/light.ejs
@@ -1,10 +1,10 @@
-# vim: filetype=yaml
-# rofi template
-# Base16 <%- scheme %> Light, by <%- author %>
+! vim: filetype=yaml
+! rofi template
+! Base16 <%- scheme %> Light, by <%- author %>
 
-# State:           'bg',    'fg',    'bgalt', 'hlbg',  'hlfg'
+! State:           'bg',    'fg',    'bgalt', 'hlbg',  'hlfg'
 rofi.color-normal: #<%- base["07"]["hex"] %>, #<%- base["02"]["hex"] %>, #<%- base["07"]["hex"] %>, #<%- base["02"]["hex"] %>, #<%- base["07"]["hex"] %>
 rofi.color-urgent: #<%- base["07"]["hex"] %>, #<%- base["08"]["hex"] %>, #<%- base["07"]["hex"] %>, #<%- base["08"]["hex"] %>, #<%- base["07"]["hex"] %>
 rofi.color-active: #<%- base["07"]["hex"] %>, #<%- base["0D"]["hex"] %>, #<%- base["07"]["hex"] %>, #<%- base["0D"]["hex"] %>, #<%- base["07"]["hex"] %>
-#                  'bg',    'border'
+!                  'bg',    'border'
 rofi.color-window: #<%- base["07"]["hex"] %>, #<%- base["02"]["hex"] %>


### PR DESCRIPTION
rofi is configured via Xresources which uses exclamation marks at the
start of a comment.

closes #109 