### PR TITLE
feat(HTML Preview): Improved the schemes preview HTML page

### DIFF
--- a/util/schemesPreview.ejs
+++ b/util/schemesPreview.ejs
@@ -6,43 +6,68 @@
   <style>
     body {
       font-family: sans;
+      background-color: #202020;
+      color: #e0e0e0;
     }
     .scheme {
 
     }
     .color-swatch {
-      width: 500px;
+      padding-left: 0;
     }
-    .color-swatch__color {
-      list-style: none;
-      height: 20px;
+    .color-circle {
+      border: 2px solid white;
+      border-radius: 50%;
+      height: 40px;
+      width: 40px;
+      display: inline-block;
+      margin-right: -25px;
+    }
+    h1 {
+      font-weight: 200;
+    }
+    h2 {
+      font-weight: 100;
+      font-size: 20px;
+      padding-left: 10px;
+    }
+    a {
+      text-decoration: none;
+      color: blue;
+      position: absolute;
+      right: 20px;
+      top: 10px;
+    }
+    hr {
+      border-color: #404040;
     }
   </style>
 </head>
 <body>
   <h1>Base16 Builder</h1>
+  <a target="_blank" href="https://www.github.com/base16-builder/base16-builder#readme">GitHub</a>
 
   <% schemes.forEach(function(scheme) { %>
+    <hr></hr>
     <div class="scheme">
       <h2 class="scheme__name"><%=scheme.scheme%></h2>
       <ul class="color-swatch">
-        <li class="color-swatch__color" style='background-color: #<%=scheme.base00%>'></li>
-        <li class="color-swatch__color" style='background-color: #<%=scheme.base01%>'></li>
-        <li class="color-swatch__color" style='background-color: #<%=scheme.base02%>'></li>
-        <li class="color-swatch__color" style='background-color: #<%=scheme.base03%>'></li>
-        <li class="color-swatch__color" style='background-color: #<%=scheme.base04%>'></li>
-        <li class="color-swatch__color" style='background-color: #<%=scheme.base05%>'></li>
-        <li class="color-swatch__color" style='background-color: #<%=scheme.base06%>'></li>
-        <li class="color-swatch__color" style='background-color: #<%=scheme.base07%>'></li>
-        <li class="color-swatch__color" style='background-color: #<%=scheme.base08%>'></li>
-        <li class="color-swatch__color" style='background-color: #<%=scheme.base09%>'></li>
-        <li class="color-swatch__color" style='background-color: #<%=scheme.base09%>'></li>
-        <li class="color-swatch__color" style='background-color: #<%=scheme.base0A%>'></li>
-        <li class="color-swatch__color" style='background-color: #<%=scheme.base0B%>'></li>
-        <li class="color-swatch__color" style='background-color: #<%=scheme.base0C%>'></li>
-        <li class="color-swatch__color" style='background-color: #<%=scheme.base0D%>'></li>
-        <li class="color-swatch__color" style='background-color: #<%=scheme.base0E%>'></li>
-        <li class="color-swatch__color" style='background-color: #<%=scheme.base0F%>'></li>
+        <li class="color-circle" style='background-color: #<%=scheme.base00%>'></li>
+        <li class="color-circle" style='background-color: #<%=scheme.base01%>'></li>
+        <li class="color-circle" style='background-color: #<%=scheme.base02%>'></li>
+        <li class="color-circle" style='background-color: #<%=scheme.base03%>'></li>
+        <li class="color-circle" style='background-color: #<%=scheme.base04%>'></li>
+        <li class="color-circle" style='background-color: #<%=scheme.base05%>'></li>
+        <li class="color-circle" style='background-color: #<%=scheme.base06%>'></li>
+        <li class="color-circle" style='background-color: #<%=scheme.base07%>'></li>
+        <li class="color-circle" style='background-color: #<%=scheme.base08%>'></li>
+        <li class="color-circle" style='background-color: #<%=scheme.base09%>'></li>
+        <li class="color-circle" style='background-color: #<%=scheme.base0A%>'></li>
+        <li class="color-circle" style='background-color: #<%=scheme.base0B%>'></li>
+        <li class="color-circle" style='background-color: #<%=scheme.base0C%>'></li>
+        <li class="color-circle" style='background-color: #<%=scheme.base0D%>'></li>
+        <li class="color-circle" style='background-color: #<%=scheme.base0E%>'></li>
+        <li class="color-circle" style='background-color: #<%=scheme.base0F%>'></li>
       </ul>
     </div>
   <% }) %>


### PR DESCRIPTION
Improved the HTML page where you preview schemes.
I tried to draw some inspiration from the mock design.

Affects #96. Probably doesn't close it though.
Saw this on Reddit today, figured I could help out.

Here's a preview:
![ls_schemes](https://cloud.githubusercontent.com/assets/6856391/16028010/f8e30d0e-31a8-11e6-92d9-4fd305e019e5.png)
