### PR TITLE
Fix [[ not found error when loading shell script from vim

### DIFF
--- a/db/templates/shell/dark.ejs
+++ b/db/templates/shell/dark.ejs
@@ -47,7 +47,7 @@ elif [ "${TERM%%-*}" = "screen" ]; then
   printf_template="\033P\033]4;%d;rgb:%s\007\033\\"
   printf_template_var="\033P\033]%d;rgb:%s\007\033\\"
   printf_template_custom="\033P\033]%s%s\007\033\\"
-elif ! [ -z "${-##*i*}" ]; then
+elif [ -n "${-##*i*}" ]; then
   # non-interactive
   alias printf=/bin/false
 else

--- a/db/templates/shell/dark.ejs
+++ b/db/templates/shell/dark.ejs
@@ -47,7 +47,7 @@ elif [ "${TERM%%-*}" = "screen" ]; then
   printf_template="\033P\033]4;%d;rgb:%s\007\033\\"
   printf_template_var="\033P\033]%d;rgb:%s\007\033\\"
   printf_template_custom="\033P\033]%s%s\007\033\\"
-elif [[ $- != *i* ]]; then
+elif ! [ -z "${-##*i*}" ]; then
   # non-interactive
   alias printf=/bin/false
 else

--- a/db/templates/shell/light.ejs
+++ b/db/templates/shell/light.ejs
@@ -47,7 +47,7 @@ elif [ "${TERM%%-*}" = "screen" ]; then
   printf_template="\033P\033]4;%d;rgb:%s\007\033\\"
   printf_template_var="\033P\033]%d;rgb:%s\007\033\\"
   printf_template_custom="\033P\033]%s%s\007\033\\"
-elif ! [ -z "${-##*i*}" ]; then
+elif [ -n "${-##*i*}" ]; then
   # non-interactive
   alias printf=/bin/false
 else

--- a/db/templates/shell/light.ejs
+++ b/db/templates/shell/light.ejs
@@ -47,7 +47,7 @@ elif [ "${TERM%%-*}" = "screen" ]; then
   printf_template="\033P\033]4;%d;rgb:%s\007\033\\"
   printf_template_var="\033P\033]%d;rgb:%s\007\033\\"
   printf_template_custom="\033P\033]%s%s\007\033\\"
-elif [[ $- != *i* ]]; then
+elif ! [ -z "${-##*i*}" ]; then
   # non-interactive
   alias printf=/bin/false
 else


### PR DESCRIPTION
When using `let g:base16_shell_path="/pathto/base16-builder/output/shell/"` in vim with vim-base16 themes. You'll see the following error every time you close vim:

```
/pathto/base16-builder/output/shell//base16-default.dark.sh: 50: /pathto/base16-builder/output/shell//base16-default.dark.sh: [[: not found
```

This PR fixes this issue by replacing the check at line 50 with a safer one that works with primitive interpreters.

I've submitted this a while ago to the original base16-builder project as well: chriskempson/base16-builder#325