### PR TITLE
Theme matching color-values for Prism's standard plugins

### DIFF
--- a/db/templates/prism-less/dark.ejs
+++ b/db/templates/prism-less/dark.ejs
@@ -164,3 +164,22 @@ pre > code.highlight {
   outline: .4em solid @base08;
   outline-offset: .4em;
 }
+
+/* overrides color-values for the Line Numbers plugin
+ * http://prismjs.com/plugins/line-numbers/
+ */
+.line-numbers .line-numbers-rows {
+  border-right-color: @base01;
+}
+
+.line-numbers-rows > span:before {
+  color: @base02;
+}
+
+/* overrides color-values for the Line Highlight plugin
+ * http://prismjs.com/plugins/line-highlight/
+ */
+.line-highlight {
+  background: fade(@base05, 20%);
+  background: linear-gradient(to right, fade(@base05, 20%) 70%, fade(@base05, 0%));
+}

--- a/db/templates/prism-less/light.ejs
+++ b/db/templates/prism-less/light.ejs
@@ -164,3 +164,22 @@ pre > code.highlight {
   outline: .4em solid @base08;
   outline-offset: .4em;
 }
+
+/* overrides color-values for the Line Numbers plugin
+ * http://prismjs.com/plugins/line-numbers/
+ */
+.line-numbers .line-numbers-rows {
+  border-right-color: @base06;
+}
+
+.line-numbers-rows > span:before {
+  color: @base05;
+}
+
+/* overrides color-values for the Line Highlight plugin
+ * http://prismjs.com/plugins/line-highlight/
+ */
+.line-highlight {
+  background: fade(@base03, 20%);
+  background: linear-gradient(to right, fade(@base03, 20%) 70%, fade(@base03, 0%));
+}

--- a/db/templates/prism-sass/dark.ejs
+++ b/db/templates/prism-sass/dark.ejs
@@ -164,3 +164,22 @@ pre > code.highlight {
   outline: .4em solid $base08;
   outline-offset: .4em;
 }
+
+/* overrides color-values for the Line Numbers plugin
+ * http://prismjs.com/plugins/line-numbers/
+ */
+.line-numbers .line-numbers-rows {
+  border-right-color: $base01;
+}
+
+.line-numbers-rows > span:before {
+  color: $base02;
+}
+
+/* overrides color-values for the Line Highlight plugin
+ * http://prismjs.com/plugins/line-highlight/
+ */
+.line-highlight {
+  background: transparentize($base05, 0.8);
+  background: linear-gradient(to right, transparentize($base05, 0.8) 70%, transparentize($base05, 1));
+}

--- a/db/templates/prism-sass/light.ejs
+++ b/db/templates/prism-sass/light.ejs
@@ -164,3 +164,22 @@ pre > code.highlight {
   outline: .4em solid $base08;
   outline-offset: .4em;
 }
+
+/* overrides color-values for the Line Numbers plugin
+ * http://prismjs.com/plugins/line-numbers/
+ */
+.line-numbers .line-numbers-rows {
+  border-right-color: $base06;
+}
+
+.line-numbers-rows > span:before {
+  color: $base05;
+}
+
+/* overrides color-values for the Line Highlight plugin
+ * http://prismjs.com/plugins/line-highlight/
+ */
+.line-highlight {
+  background: transparentize($base03, 0.8);
+  background: linear-gradient(to right, transparentize($base03, 0.8) 70%, transparentize($base03, 1));
+}

--- a/db/templates/prism-stylus/dark.ejs
+++ b/db/templates/prism-stylus/dark.ejs
@@ -164,3 +164,22 @@ pre > code.highlight {
   outline: .4em solid $base08;
   outline-offset: .4em;
 }
+
+/* overrides color-values for the Line Numbers plugin
+ * http://prismjs.com/plugins/line-numbers/
+ */
+.line-numbers .line-numbers-rows {
+  border-right-color: $base01;
+}
+
+.line-numbers-rows > span:before {
+  color: $base02;
+}
+
+/* overrides color-values for the Line Highlight plugin
+ * http://prismjs.com/plugins/line-highlight/
+ */
+.line-highlight {
+  background: alpha($base05, 0.2);
+  background: linear-gradient(to right, alpha($base05, 0.2) 70%, alpha($base05, 0));
+}

--- a/db/templates/prism-stylus/light.ejs
+++ b/db/templates/prism-stylus/light.ejs
@@ -164,3 +164,22 @@ pre > code.highlight {
   outline: .4em solid $base08;
   outline-offset: .4em;
 }
+
+/* overrides color-values for the Line Numbers plugin
+ * http://prismjs.com/plugins/line-numbers/
+ */
+.line-numbers .line-numbers-rows {
+  border-right-color: $base06;
+}
+
+.line-numbers-rows > span:before {
+  color: $base05;
+}
+
+/* overrides color-values for the Line Highlight plugin
+ * http://prismjs.com/plugins/line-highlight/
+ */
+.line-highlight {
+  background: alpha($base03, 0.2);
+  background: linear-gradient(to right, alpha($base03, 0.2) 70%, alpha($base03, 0));
+}

--- a/db/templates/prism/dark.ejs
+++ b/db/templates/prism/dark.ejs
@@ -147,3 +147,24 @@ pre > code.highlight {
   outline: .4em solid #<%- base["08"]["hex"] %>;
   outline-offset: .4em;
 }
+
+/* overrides color-values for the Line Numbers plugin
+ * http://prismjs.com/plugins/line-numbers/
+ */
+.line-numbers .line-numbers-rows {
+  border-right-color: #<%- base["01"]["hex"] %>;
+}
+
+.line-numbers-rows > span:before {
+  color: #<%- base["02"]["hex"] %>;
+}
+
+/* overrides color-values for the Line Highlight plugin
+ * http://prismjs.com/plugins/line-highlight/
+ * alpha transparency in 8 digits hex notation coming to a browser near you soon:
+ * https://drafts.csswg.org/css-color/#hex-notation
+ */
+.line-highlight {
+  background: #<%- base["05"]["hex"] %>33;
+  background: linear-gradient(to right, #<%- base["05"]["hex"] %>33 70%, #<%- base["05"]["hex"] %>00);
+}

--- a/db/templates/prism/light.ejs
+++ b/db/templates/prism/light.ejs
@@ -147,3 +147,24 @@ pre > code.highlight {
   outline: .4em solid #<%- base["08"]["hex"] %>;
   outline-offset: .4em;
 }
+
+/* overrides color-values for the Line Numbers plugin
+ * http://prismjs.com/plugins/line-numbers/
+ */
+.line-numbers .line-numbers-rows {
+  border-right-color: #<%- base["06"]["hex"] %>;
+}
+
+.line-numbers-rows > span:before {
+  color: #<%- base["05"]["hex"] %>;
+}
+
+/* overrides color-values for the Line Highlight plugin
+ * http://prismjs.com/plugins/line-highlight/
+ * alpha transparency in 8 digits hex notation coming to a browser near you soon:
+ * https://drafts.csswg.org/css-color/#hex-notation
+ */
+.line-highlight {
+  background: #<%- base["03"]["hex"] %>33;
+  background: linear-gradient(to right, #<%- base["03"]["hex"] %>33 70%, #<%- base["03"]["hex"] %>00);
+}


### PR DESCRIPTION
Added a few declaration-blocks with theme matching color-values for Prism's Line-number and Line-highlighter plugins. 

I'll try to keep these templates in sync with [the theme repo by PrismJS](https://github.com/PrismJS/prism-themes); PR there as well. See also [this issue over there](https://github.com/PrismJS/prism-themes/issues/51). 

Using [alpha transparency in 8 digits hex notation](http://codepen.io/atelierbram/pen/bZAGmW) in `db/templates/prism/*.ejs` on the `.line-highlight` declaration-block for the CSS version. Early days for sure because HEXA just landed this spring in Chrome Canary and Firefox Nightly, but should be OK IMO for it is just an enhancement which can be:

1. converted to either rgba or hsla by the end-user
2. will fall back on the hsla value set by [the plugin's CSS](http://prismjs.com/plugins/line-highlight/prism-line-highlight.css)

The good news of course is that HEXA allows template creators for Base16 Builder to generate alpha transparency values for color-variables on a template level, which is awesome!

```css
/* overrides color-values for the Line Highlight plugin
 * http://prismjs.com/plugins/line-highlight/
 * alpha transparency in 8 digits hex notation coming to a browser near you soon:
 * https://drafts.csswg.org/css-color/#hex-notation
 */
.line-highlight {
  background: #<%- base["05"]["hex"] %>33;
  background: linear-gradient(to right, #<%- base["05"]["hex"] %>33 70%, #<%- base["05"]["hex"] %>00);
} 
```

P.S. will look into commitizen next time, was not aware of this.