### PR TITLE
Improved i3status config

### DIFF
--- a/db/templates/i3status/dark.ejs
+++ b/db/templates/i3status/dark.ejs
@@ -5,7 +5,7 @@
 general {
     colors = true
     color_good = "#<%- base["0B"]["hex"] %>"
-    color_bad = "<%- base["08"]["hex"] %>"
+    color_bad = "#<%- base["08"]["hex"] %>"
     ## remember to add your prefered interval
     # interval = 5
 }

--- a/db/templates/i3status/light.ejs
+++ b/db/templates/i3status/light.ejs
@@ -5,7 +5,7 @@
 general {
     colors = true
     color_good = "#<%- base["0B"]["hex"] %>"
-    color_bad = "<%- base["08"]["hex"] %>"
+    color_bad = "#<%- base["08"]["hex"] %>"
     ## remember to add your prefered interval
     # interval = 5
 }


### PR DESCRIPTION
In i3status, there was an error: the generated config wansn't correct due to missing `#`

see #145 
