### PR TITLE
fix(cli): Change cli to handle number-named schemas

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -84,7 +84,7 @@ import updateNotifier from 'update-notifier'
     return
   }
 
-  schemeNameOrPath = schemeNameOrPath.toLowerCase()
+  schemeNameOrPath = schemeNameOrPath.toString().toLowerCase()
   templNameOrPath = templNameOrPath.toLowerCase()
 
   let templPath


### PR DESCRIPTION
Schemas with a numeric name like `3024` are automatically converted to numbers by `meow`, so call `.toString()` to force a string first.