### PR TITLE
Fixed shell templates.

### DIFF
--- a/db/templates/shell/dark.ejs
+++ b/db/templates/shell/dark.ejs
@@ -1,7 +1,4 @@
-#{
-# Shell Color Setup Template
-# Chris Kempson (http://chriskempson.com)
-#}#!/bin/sh
+#!/bin/sh
 # Base16 <%- scheme %> - Shell color setup script
 # <%- author %>
 
@@ -39,21 +36,18 @@ color_cursor="<%- base["05"]["hex"].match(/.{2}/g).join('/') %>" # Base 05
 if [ -n "$TMUX" ]; then
   # tell tmux to pass the escape sequences through
   # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
-  printf_template="\033Ptmux;\033\033]4;%d;rgb:%s\007\033\\"
-  printf_template_var="\033Ptmux;\033\033]%d;rgb:%s\007\033\\"
-  printf_template_custom="\033Ptmux;\033\033]%s%s\007\033\\"
+  printf_template='\033Ptmux;\033\033]4;%d;rgb:%s\007\033\\'
+  printf_template_var='\033Ptmux;\033\033]%d;rgb:%s\007\033\\'
+  printf_template_custom='\033Ptmux;\033\033]%s%s\007\033\\'
 elif [ "${TERM%%-*}" = "screen" ]; then
   # GNU screen (screen, screen-256color, screen-256color-bce)
-  printf_template="\033P\033]4;%d;rgb:%s\007\033\\"
-  printf_template_var="\033P\033]%d;rgb:%s\007\033\\"
-  printf_template_custom="\033P\033]%s%s\007\033\\"
-elif [ -n "${-##*i*}" ]; then
-  # non-interactive
-  alias printf=/bin/false
+  printf_template='\033P\033]4;%d;rgb:%s\007\033\\'
+  printf_template_var='\033P\033]%d;rgb:%s\007\033\\'
+  printf_template_custom='\033P\033]%s%s\007\033\\'
 else
-  printf_template="\033]4;%d;rgb:%s\033\\"
-  printf_template_var="\033]%d;rgb:%s\033\\"
-  printf_template_custom="\033]%s%s\033\\"
+  printf_template='\033]4;%d;rgb:%s\033\\'
+  printf_template_var='\033]%d;rgb:%s\033\\'
+  printf_template_custom='\033]%s%s\033\\'
 fi
 
 # 16 color space

--- a/db/templates/shell/light.ejs
+++ b/db/templates/shell/light.ejs
@@ -1,7 +1,4 @@
-#{
-# Shell Color Setup Template
-# Chris Kempson (http://chriskempson.com)
-#}#!/bin/sh
+#!/bin/sh
 # Base16 <%- scheme %> - Shell color setup script
 # <%- author %>
 
@@ -39,21 +36,18 @@ color_cursor="<%- base["02"]["hex"].match(/.{2}/g).join('/') %>" # Base 02
 if [ -n "$TMUX" ]; then
   # tell tmux to pass the escape sequences through
   # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
-  printf_template="\033Ptmux;\033\033]4;%d;rgb:%s\007\033\\"
-  printf_template_var="\033Ptmux;\033\033]%d;rgb:%s\007\033\\"
-  printf_template_custom="\033Ptmux;\033\033]%s%s\007\033\\"
+  printf_template='\033Ptmux;\033\033]4;%d;rgb:%s\007\033\\'
+  printf_template_var='\033Ptmux;\033\033]%d;rgb:%s\007\033\\'
+  printf_template_custom='\033Ptmux;\033\033]%s%s\007\033\\'
 elif [ "${TERM%%-*}" = "screen" ]; then
   # GNU screen (screen, screen-256color, screen-256color-bce)
-  printf_template="\033P\033]4;%d;rgb:%s\007\033\\"
-  printf_template_var="\033P\033]%d;rgb:%s\007\033\\"
-  printf_template_custom="\033P\033]%s%s\007\033\\"
-elif [ -n "${-##*i*}" ]; then
-  # non-interactive
-  alias printf=/bin/false
+  printf_template='\033P\033]4;%d;rgb:%s\007\033\\'
+  printf_template_var='\033P\033]%d;rgb:%s\007\033\\'
+  printf_template_custom='\033P\033]%s%s\007\033\\'
 else
-  printf_template="\033]4;%d;rgb:%s\033\\"
-  printf_template_var="\033]%d;rgb:%s\033\\"
-  printf_template_custom="\033]%s%s\033\\"
+  printf_template='\033]4;%d;rgb:%s\033\\'
+  printf_template_var='\033]%d;rgb:%s\033\\'
+  printf_template_custom='\033]%s%s\033\\'
 fi
 
 # 16 color space


### PR DESCRIPTION
They were broken in three ways:
1. They had leftover junk from a mustache template that was blocking the
   hashbang.
2. They had double quotes where single quotes were needed.
3. They were checking for interactive mode in a way that's incompatible
   with fish_shell. I just deleted the check; I suspect that that's the
   sort of check the user should do before calling the file (rather than
   the sort of check that should be done by the file itself).