### PR TITLE
added template for lightline - Vim statusline plugin

### DIFF
--- a/db/templates/vim-lightline/both.ejs
+++ b/db/templates/vim-lightline/both.ejs
@@ -1,0 +1,78 @@
+" Filename: <%- scheme %>.vim
+" Scheme: Base16 <%- scheme %> by <%- author %>
+" vim-lightline template by Bram de Haan (https://github.com/atelierbram/vim-colors_atelier-schemes/blob/master/db/templates/lightline/template.ejs)
+" adapted from solarized.vim for lightline (https://github.com/itchyny/lightline.vim/blob/master/autoload/lightline/colorscheme/solarized.vim) by itchyny (https://github.com/itchyny)
+
+let s:cuicolors = {
+      \ 'base03': [ '8', '234', 'DarkGray' ],
+      \ 'base02': [ '0', '235', 'Black' ],
+      \ 'base01': [ '10', '239', 'LightGreen' ],
+      \ 'base00': [ '11', '240', 'LightYellow' ],
+      \ 'base0':  [ '12', '244', 'LightBlue' ],
+      \ 'base1':  [ '14', '245', 'LightCyan' ],
+      \ 'base2': [ '7', '187', 'LightGray' ],
+      \ 'base3': [ '15', '230', 'White' ],
+      \ 'yellow': [ '3', '136', 'DarkYellow' ],
+      \ 'orange': [ '9', '166', 'LightRed' ],
+      \ 'red': [ '1', '124', 'DarkRed' ],
+      \ 'magenta': [ '5', '125', 'DarkMagenta' ],
+      \ 'violet': [ '13', '61', 'LightMagenta' ],
+      \ 'blue': [ '4', '33', 'DarkBlue' ],
+      \ 'cyan': [ '6', '37', 'DarkCyan' ],
+      \ 'green': [ '2', '64', 'DarkGreen' ],
+      \ }
+
+" The following condition only applies for the console and is the same
+" condition vim-colors-<%- scheme %> uses to determine which set of colors
+" to use.
+let s:<%- scheme %>_termcolors = get(g:, '<%- scheme %>_termcolors', 256)
+if s:<%- scheme %>_termcolors != 256 && &t_Co >= 16
+  let s:cuiindex = 0
+elseif s:<%- scheme %>_termcolors == 256
+  let s:cuiindex = 1
+else
+  let s:cuiindex = 2
+endif
+
+let s:base03 = [ '#<%- base["00"]["hex"] %>', s:cuicolors.base03[s:cuiindex] ]
+let s:base02 = [ '#<%- base["01"]["hex"] %>', s:cuicolors.base02[s:cuiindex] ]
+let s:base01 = [ '#<%- base["02"]["hex"] %>', s:cuicolors.base01[s:cuiindex] ]
+let s:base00 = [ '#<%- base["03"]["hex"] %>', s:cuicolors.base00[s:cuiindex] ]
+let s:base0 = [ '#<%- base["04"]["hex"] %>', s:cuicolors.base0[s:cuiindex] ]
+let s:base1 = [ '#<%- base["05"]["hex"] %>', s:cuicolors.base1[s:cuiindex] ]
+let s:base2 = [ '#<%- base["06"]["hex"] %>', s:cuicolors.base2[s:cuiindex] ]
+let s:base3 = [ '#<%- base["07"]["hex"] %>', s:cuicolors.base3[s:cuiindex] ]
+let s:yellow = [ '#<%- base["0A"]["hex"] %>', s:cuicolors.yellow[s:cuiindex] ]
+let s:orange = [ '#<%- base["09"]["hex"] %>', s:cuicolors.orange[s:cuiindex] ]
+let s:red = [ '#<%- base["08"]["hex"] %>', s:cuicolors.red[s:cuiindex] ]
+let s:magenta = [ '#<%- base["0F"]["hex"] %>', s:cuicolors.magenta[s:cuiindex] ]
+let s:violet = [ '#<%- base["0E"]["hex"] %>', s:cuicolors.violet[s:cuiindex] ]
+let s:blue = [ '#<%- base["0D"]["hex"] %>', s:cuicolors.blue[s:cuiindex] ]
+let s:cyan = [ '#<%- base["0C"]["hex"] %>', s:cuicolors.cyan[s:cuiindex] ]
+let s:green = [ '#<%- base["0B"]["hex"] %>', s:cuicolors.green[s:cuiindex] ]
+
+if lightline#colorscheme#background() ==# 'light'
+  let [ s:base03, s:base3 ] = [ s:base3, s:base03 ]
+  let [ s:base02, s:base2 ] = [ s:base2, s:base02 ]
+  let [ s:base01, s:base1 ] = [ s:base1, s:base01 ]
+  let [ s:base00, s:base0 ] = [ s:base0, s:base00 ]
+endif
+
+let s:p = {'normal': {}, 'inactive': {}, 'insert': {}, 'replace': {}, 'visual': {}, 'tabline': {}}
+let s:p.normal.left = [ [ s:base03, s:blue ], [ s:base03, s:base00 ] ]
+let s:p.normal.right = [ [ s:base03, s:base1 ], [ s:base03, s:base00 ] ]
+let s:p.inactive.right = [ [ s:base03, s:base00 ], [ s:base0, s:base02 ] ]
+let s:p.inactive.left =  [ [ s:base0, s:base02 ], [ s:base0, s:base02 ] ]
+let s:p.insert.left = [ [ s:base03, s:green ], [ s:base03, s:base00 ] ]
+let s:p.replace.left = [ [ s:base03, s:red ], [ s:base03, s:base00 ] ]
+let s:p.visual.left = [ [ s:base03, s:magenta ], [ s:base03, s:base00 ] ]
+let s:p.normal.middle = [ [ s:base1, s:base02 ] ]
+let s:p.inactive.middle = [ [ s:base01, s:base02 ] ]
+let s:p.tabline.left = [ [ s:base03, s:base00 ] ]
+let s:p.tabline.tabsel = [ [ s:base03, s:base1 ] ]
+let s:p.tabline.middle = [ [ s:base0, s:base02 ] ]
+let s:p.tabline.right = copy(s:p.normal.right)
+let s:p.normal.error = [ [ s:base03, s:red ] ]
+let s:p.normal.warning = [ [ s:base03, s:yellow ] ]
+
+let g:lightline#colorscheme#<%- scheme %>#palette = lightline#colorscheme#flatten(s:p)


### PR DESCRIPTION
[Lightline](https://github.com/itchyny/lightline.vim) is a light and configurable statusline/tabline plugin for Vim. This will likely by a better fit when using Neovim, for it's minimalism, compared to the other popular statusline plugins for Vim (_it will not make Neovim crash_ :smirk:).

I used and only slightly adapted the lightline [Solarized colorscheme](https://github.com/itchyny/lightline.vim/blob/master/autoload/lightline/colorscheme/solarized.vim) for this template . Since base16-builder doesn't have 256 color support (not defined in schemes) it uses the 256-colors defined for Solarized in terminals without true-color support.