### PR TITLE
using underscores ISO hyphens for scheme names

### DIFF
--- a/db/schemes/atelier_cave.yml
+++ b/db/schemes/atelier_cave.yml
@@ -1,4 +1,4 @@
-scheme: "Atelier Cave"
+scheme: "Atelier_Cave"
 author: "Bram de Haan (http://atelierbram.github.io/syntax-highlighting/atelier-schemes/cave)"
 base00: "19171c"
 base01: "26232a"

--- a/db/schemes/atelier_dune.yml
+++ b/db/schemes/atelier_dune.yml
@@ -1,4 +1,4 @@
-scheme: "Atelier Dune"
+scheme: "Atelier_Dune"
 author: "Bram de Haan (http://atelierbram.github.io/syntax-highlighting/atelier-schemes/dune)"
 base00: "20201d"
 base01: "292824"

--- a/db/schemes/atelier_estuary.yml
+++ b/db/schemes/atelier_estuary.yml
@@ -1,4 +1,4 @@
-scheme: "Atelier Estuary"
+scheme: "Atelier_Estuary"
 author: "Bram de Haan (http://atelierbram.github.io/syntax-highlighting/atelier-schemes/estuary)"
 base00: "22221b"
 base01: "302f27"

--- a/db/schemes/atelier_forest.yml
+++ b/db/schemes/atelier_forest.yml
@@ -1,4 +1,4 @@
-scheme: "Atelier Forest"
+scheme: "Atelier_Forest"
 author: "Bram de Haan (http://atelierbram.github.io/syntax-highlighting/atelier-schemes/forest)"
 base00: "1b1918"
 base01: "2c2421"

--- a/db/schemes/atelier_heath.yml
+++ b/db/schemes/atelier_heath.yml
@@ -1,4 +1,4 @@
-scheme: "Atelier Heath"
+scheme: "Atelier_Heath"
 author: "Bram de Haan (http://atelierbram.github.io/syntax-highlighting/atelier-schemes/heath)"
 base00: "1b181b"
 base01: "292329"

--- a/db/schemes/atelier_lakeside.yml
+++ b/db/schemes/atelier_lakeside.yml
@@ -1,4 +1,4 @@
-scheme: "Atelier Lakeside"
+scheme: "Atelier_Lakeside"
 author: "Bram de Haan (http://atelierbram.github.io/syntax-highlighting/atelier-schemes/lakeside/)"
 base00: "161b1d"
 base01: "1f292e"

--- a/db/schemes/atelier_plateau.yml
+++ b/db/schemes/atelier_plateau.yml
@@ -1,4 +1,4 @@
-scheme: "Atelier Plateau"
+scheme: "Atelier_Plateau"
 author: "Bram de Haan (http://atelierbram.github.io/syntax-highlighting/atelier-schemes/plateau)"
 base00: "1b1818"
 base01: "292424"

--- a/db/schemes/atelier_savanna.yml
+++ b/db/schemes/atelier_savanna.yml
@@ -1,4 +1,4 @@
-scheme: "Atelier Savanna"
+scheme: "Atelier_Savanna"
 author: "Bram de Haan (http://atelierbram.github.io/syntax-highlighting/atelier-schemes/savanna)"
 base00: "171c19"
 base01: "232a25"

--- a/db/schemes/atelier_seaside.yml
+++ b/db/schemes/atelier_seaside.yml
@@ -1,4 +1,4 @@
-scheme: "Atelier Seaside"
+scheme: "Atelier_Seaside"
 author: "Bram de Haan (http://atelierbram.github.io/syntax-highlighting/atelier-schemes/seaside/)"
 base00: "131513"
 base01: "242924"

--- a/db/schemes/atelier_sulphurpool.yml
+++ b/db/schemes/atelier_sulphurpool.yml
@@ -1,4 +1,4 @@
-scheme: "Atelier Sulphurpool"
+scheme: "Atelier_Sulphurpool"
 author: "Bram de Haan (http://atelierbram.github.io/syntax-highlighting/atelier-schemes/sulphurpool)"
 base00: "202746"
 base01: "293256"


### PR DESCRIPTION
My Atelier-Schemes have hyphens in their file-name, and a space in the scheme-name within the scheme-files, which can lead to problems with generating valid theme-files from some templates. Changing the hyphens and spaces to underscores fixes any potential issue that can come up with using the `<%- scheme %>`  variable in base16-builder.