### PR TITLE
fix(vim): only reset syntax if already initialized

### DIFF
--- a/db/templates/vim/dark.ejs
+++ b/db/templates/vim/dark.ejs
@@ -58,7 +58,9 @@ endif
 
 " Theme setup
 hi clear
-syntax reset
+if exists("syntax_on")
+  syntax reset
+endif
 let g:colors_name = "base16-<%- schemeSlug %>"
 
 " Highlighting function

--- a/db/templates/vim/light.ejs
+++ b/db/templates/vim/light.ejs
@@ -58,7 +58,9 @@ endif
 
 " Theme setup
 hi clear
-syntax reset
+if exists("syntax_on")
+  syntax reset
+endif
 let g:colors_name = "base16-<%- schemeSlug %>"
 
 " Highlighting function


### PR DESCRIPTION
Without this, the 'syntax reset' line causes some of the Vim syntax
runtime scripts to be sourced multiple times on startup.

Note that this is also the pattern that most of the default colorschemes
use, so it's a good idea to be idiomatic anyway.